### PR TITLE
hoops #38 vercel 배포를 위한 GitHub Actions 설정 파일 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: 'output'
+          destination-github-username: osw6858
+          destination-repository-name: hoops-frontend
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./frontend/* ./output
+cp -R ./output ./frontend/


### PR DESCRIPTION
작업 목적 
- 서버 연동전 vercel에 프론트엔드를 배포하기 위함

작업내용
- main에 push 할때마다 자동으로 배포가 이루어 지도록 설정파일을 작성하였습니다.
- vercel에 Organization에 있는 레포지토리를 배포할 경우 2주 트라이얼 후 요금이 부과됩니다.
- 이를 피하기 위하여 깃허브 액션을 이용하여 **Organization** 브렌치에 push가 일어나면 fork한 레포(Vercel과 연동된 레포)가 자동으로  **Organization** 의 main과 동기화 되게 설정하였습니다.

해당 GitHub Actions 워크플로우 파일의 코드에 대해서 설명하자면

```yaml
name: Deploy
```
이 부분은 해당 워크플로우의 이름을 "Deploy"로 지정한 것입니다.

```yaml
on:
  push:
    branches: ['main']
```
이 부분은 워크플로우가 실행될 트리거를 설정하는 부분입니다. `main` 브랜치에 push 이벤트가 발생하면 이 워크플로우가 실행됩니다.

```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    container: pandoc/latex
```
여기서 `jobs` 블록은 실행될 작업들을 정의합니다. `build`라는 작업이 Ubuntu 최신 버전의 가상 환경에서 `pandoc/latex` 컨테이너 이미지를 사용하여 실행됩니다.

```yaml
    steps:
      - uses: actions/checkout@v2
```
이 단계에서는 `actions/checkout@v2` 액션을 사용하여 리포지토리의 코드를 가상 환경으로 체크아웃합니다.

```yaml
      - name: Install mustache (to update the date)
        run: apk add ruby && gem install mustache
```
이 단계에서는 "mustache" 루비 젬을 설치합니다. 주석에 따르면 날짜 업데이트에 사용될 것으로 보입니다.

```yaml
      - name: creates output
        run: sh ./build.sh
```
이 단계에서는 `build.sh` 쉘 스크립트를 실행하여 출력물을 생성합니다.

```yaml
      - name: Pushes to another repository
        id: push_directory
        uses: cpina/github-action-push-to-another-repository@main
        env:
          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
        with:
          source-directory: 'output'
          destination-github-username: osw6858
          destination-repository-name: hoops-frontend
          user-email: ${{ secrets.EMAIL }}
          commit-message: ${{ github.event.commits[0].message }}
          target-branch: main
```
이 단계가 가장 중요한 부분입니다. `cpina/github-action-push-to-another-repository@main` 액션을 사용하여 생성된 `output` 디렉토리의 내용을 `osw6858` 사용자의 `hoops-frontend` 리포지토리의 `main` 브랜치로 푸시합니다. 이를 위해 `AUTO_ACTIONS` 시크릿에 저장된 GitHub API 토큰을 사용하고, 커밋 메시지는 이번 푸시의 커밋 메시지를 그대로 사용합니다.

```yaml
      - name: Test get variable exported by push-to-another-repository
        run: echo $DESTINATION_CLONED_DIRECTORY
```
마지막 단계에서는 `push-to-another-repository` 액션에 의해 내보내진 `DESTINATION_CLONED_DIRECTORY` 변수의 값을 출력합니다. 이 변수는 액션에 의해 클론된 대상 리포지토리의 경로를 가리킵니다.

결론적으로 `main` 브랜치에 푸시가 발생하면 빌드 스크립트를 실행하고, 그 결과물을 `hoops-frontend` 리포지토리의 `main` 브랜치에 푸시하는 역할을 합니다.