### PR TITLE
hoops #40 나의 경기 페이지 UI 수정 및 Main Nav 수정

### DIFF
--- a/src/components/ChatList/ChatList.style.ts
+++ b/src/components/ChatList/ChatList.style.ts
@@ -2,11 +2,13 @@ import styled from 'styled-components'
 
 export const S = {
   Wrapper: styled.div`
-    height: calc(100vh - 20rem);
+    display: flex;
+    flex-direction: column;
     overflow-y: scroll;
+    height: calc(100vh - 30rem);
   `,
   Chat: styled.div`
-    margin: 2rem 0 2rem 2rem;
+    margin: 1rem 0 1rem 2rem;
     & > p {
       font-size: 1.2rem;
       padding-left: 4.5rem;

--- a/src/components/GameChat/GameChat.style.ts
+++ b/src/components/GameChat/GameChat.style.ts
@@ -5,6 +5,7 @@ export const S = {
   Wrapper: styled.div`
     position: relative;
     width: 100%;
+    height: calc(100vh - 10rem);
     background-color: ${({ theme }) => theme.colors.white};
   `,
   TopTitleContainer: styled.div`

--- a/src/components/GameUserList/GameUserList.style.ts
+++ b/src/components/GameUserList/GameUserList.style.ts
@@ -7,8 +7,9 @@ export const S = {
     padding: 2rem 0 2rem 0;
 
     & > div:first-of-type {
-      max-height: 25rem;
       margin-top: 2rem;
+      height: calc(100vh - 82rem);
+      min-height: 10rem;
       overflow-y: scroll;
     }
     & > p {

--- a/src/components/MainNav/MainNav.tsx
+++ b/src/components/MainNav/MainNav.tsx
@@ -1,7 +1,6 @@
 import { S } from './MainNav.style.ts'
 import makeGroup from '../../assets/make-group.svg'
 import myGame from '../../assets/my-game.jpg'
-import girl from '../../assets/girl.svg'
 import lastGame from '../../assets/last-game.svg'
 import friends from '../../assets/friends.svg'
 import { CS } from '../../styles/commonStyle.ts'
@@ -19,12 +18,6 @@ export default function MainNav() {
         <div>
           <img src={myGame} alt={'나의 경기'} />
           <p>나의 경기</p>
-        </div>
-      </CS.Link>
-      <CS.Link to={'/'}>
-        <div>
-          <img src={girl} alt={'여성 경기'} />
-          <p>여성 경기</p>
         </div>
       </CS.Link>
       <CS.Link to={'/'}>

--- a/src/components/MyGameList/MyGameList.style.ts
+++ b/src/components/MyGameList/MyGameList.style.ts
@@ -4,6 +4,9 @@ export const S = {
   Wrapper: styled.div`
     background: ${(props) => props.theme.colors.white};
     padding: 2rem;
+    display: flex;
+    flex-direction: column;
+
     & > p {
       font-size: 2rem;
       font-weight: bold;
@@ -13,6 +16,8 @@ export const S = {
     margin-bottom: 3rem;
     & > div:nth-child(1) {
       margin-bottom: 1.5rem;
+      display: flex;
+      flex-direction: column;
     }
   `,
 }

--- a/src/components/ParticipationGameList/ParticipationGameList.style.ts
+++ b/src/components/ParticipationGameList/ParticipationGameList.style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 export const S = {
   Wrapper: styled.div`
     background-color: ${(props) => props.theme.colors.white};
-    height: 100vh;
+    height: calc(100vh - 10rem);
 
     & > p {
       width: 100%;

--- a/src/components/WaitChatSelect/WaitChatSelect.style.ts
+++ b/src/components/WaitChatSelect/WaitChatSelect.style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const S = {
   Container: styled.div`
-    height: 100vh;
+    height: calc(100vh - 10rem);
     background-color: ${(props) => props.theme.colors.white};
     display: flex;
     align-items: center;

--- a/src/pages/MyGame/MyGame.style.ts
+++ b/src/pages/MyGame/MyGame.style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const S = {
   Wrapper: styled.div`
-    padding: 3rem 0 3rem 0;
+    padding-top: 3rem;
     height: 100%;
     display: grid;
     width: 100%;


### PR DESCRIPTION
작업 목적
- 나의 경기 페이지에서 스크롤을 내리지 않고도 바로 채팅을 칠 수 있도록 하기 위함

작업내용

- 나의 경기 페이지에 들어갈때 채팅창의 높이를 사용자가 채팅을 바로 입력 가능하도록 높이를 조정하였습니다.
- 메인 페이지에서 여성 경기 Nav 아이콘을 제거 하였습니다.

<img width="1709" alt="image" src="https://github.com/hoops-project/frontend/assets/107461545/5cd6b6de-1468-4de8-ae29-5556311bb53e">
<img width="1708" alt="image" src="https://github.com/hoops-project/frontend/assets/107461545/f863c066-dc91-4f43-b47d-1200bc2148f4">





