### PR TITLE
hoops #47 react-icon을 이용한 일부 아이콘 통일화 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.51.3",
+        "react-icons": "^5.2.1",
         "react-kakao-maps-sdk": "^1.1.26",
         "react-material-ui-carousel": "^3.4.2",
         "react-router-dom": "^6.23.0",
@@ -5073,6 +5074,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.3",
+    "react-icons": "^5.2.1",
     "react-kakao-maps-sdk": "^1.1.26",
     "react-material-ui-carousel": "^3.4.2",
     "react-router-dom": "^6.23.0",

--- a/src/components/GameUserList/GameUserList.style.ts
+++ b/src/components/GameUserList/GameUserList.style.ts
@@ -24,8 +24,10 @@ export const S = {
     align-items: center;
     padding: 1.5rem;
 
-    & > img {
+    & > svg {
       cursor: pointer;
+      width: 2rem;
+      height: 2rem;
     }
   `,
 }

--- a/src/components/GameUserList/GameUserList.tsx
+++ b/src/components/GameUserList/GameUserList.tsx
@@ -1,8 +1,8 @@
 import { S } from './GameUserList.style.ts'
 import BasicButton from '../common/BasicButton/BasicButton.tsx'
 import { theme } from '../../styles/theme.ts'
-import reportIcon from '../../assets/report_icon.svg'
 import { MyGameUserList } from '../../types/game.ts'
+import { PiSirenThin } from 'react-icons/pi'
 
 export default function GameUserList({ userInfo }: MyGameUserList) {
   const userId = 1
@@ -26,7 +26,7 @@ export default function GameUserList({ userInfo }: MyGameUserList) {
                 >
                   친구 추가
                 </BasicButton>
-                <img src={reportIcon} alt={'신고 아이콘'} />
+                <PiSirenThin />
               </S.UserInfo>
             )
         )}

--- a/src/components/MyGameItem/MyGameItem.style.ts
+++ b/src/components/MyGameItem/MyGameItem.style.ts
@@ -36,5 +36,10 @@ export const S = {
         color: ${(props) => props.theme.colors.gray_500};
       }
     }
+
+    & > svg {
+      width: 2rem;
+      height: 2rem;
+    }
   `,
 }

--- a/src/components/MyGameItem/MyGameItem.tsx
+++ b/src/components/MyGameItem/MyGameItem.tsx
@@ -2,8 +2,8 @@ import { S } from './MyGameItem.style.ts'
 import Badge from '../common/Badge/Badge.tsx'
 import { theme } from '../../styles/theme.ts'
 import { MyGameItemProps } from '../../types/game.ts'
-import enterDoor from '../../assets/enter_door.svg'
 import { useNavigate } from 'react-router-dom'
+import { PiArrowSquareInLight } from 'react-icons/pi'
 
 export default function MyGameItem({
   gameInfo,
@@ -38,7 +38,7 @@ export default function MyGameItem({
         <p>날짜</p>
         <p>{gameInfo.startDateTime}</p>
       </div>
-      <img src={enterDoor} alt={'입장 아이콘'} />
+      <PiArrowSquareInLight />
     </S.GameItem>
   )
 }

--- a/src/components/Notification/Notification.style.ts
+++ b/src/components/Notification/Notification.style.ts
@@ -54,8 +54,10 @@ export const S = {
     padding-left: 1rem;
     font-size: 1.4rem;
 
-    & > img {
+    & > svg {
       margin-right: 1rem;
+      width: 2rem;
+      height: 2rem;
     }
   `,
 }

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,7 +1,7 @@
 import { S } from './Notification.style.ts'
 import noticeBell from '../../assets/fluent-emoji-flat_bell.svg'
-import vector from '../../assets/Vector.svg'
 import { CS } from '../../styles/commonStyle.ts'
+import { PiInfoLight } from 'react-icons/pi'
 
 export default function Notification() {
   return (
@@ -20,7 +20,7 @@ export default function Notification() {
         {Array.from({ length: 10 }, (_, index) => (
           <CS.Link to={'/'} key={index}>
             <S.NoticeItem key={index}>
-              <img src={vector} alt={'느낌표 아이콘'} />
+              <PiInfoLight />
               <p>{`시눙하이 님이 초대를 보냈습니다.`}</p>
             </S.NoticeItem>
           </CS.Link>

--- a/src/components/common/RequestItem/RequestItem.style.ts
+++ b/src/components/common/RequestItem/RequestItem.style.ts
@@ -8,7 +8,9 @@ export const S = {
     padding: 1rem;
     border-bottom: 0.1rem solid ${(props) => props.theme.colors.gray_300};
 
-    & > img {
+    & > svg {
+      width: 2.2rem;
+      height: 2.2rem;
       cursor: pointer;
     }
   `,

--- a/src/components/common/RequestItem/RequestItem.tsx
+++ b/src/components/common/RequestItem/RequestItem.tsx
@@ -1,13 +1,13 @@
-import vector from '../../../assets/Vector.svg'
 import BasicButton from '../BasicButton/BasicButton.tsx'
 import { theme } from '../../../styles/theme.ts'
 import { S } from './RequestItem.style.ts'
+import { PiInfoLight } from 'react-icons/pi'
 
 export default function RequestItem() {
   return (
     <S.RequestItem>
       <p>{`오신웅`}</p>
-      <img src={vector} alt={'느낌표 아이콘'} />
+      <PiInfoLight />
       <p>{`4.9`}</p>
       <S.ButtonWrapper>
         <BasicButton


### PR DESCRIPTION
작업목적
- 페이지에 통일감을 해치는 일부 두꺼운 선을 가진 아이콘을 교체하여 통일감을 부여하기 위함

작업 내용
- react-icon을 이용하여 일부 아이콘을 교체하여 UI적으로 통일감을 줄 수 있도록 하였습니다.
- react-icons중 Phosphor Icons을 선택하여 작업하였습니다.
- 추후 아이콘이 필요한 경우 react-icons 아이콘 종류 중 Phosphor Icons 을 이용하여 작업하면 통일감을 줄 수 있을 것 같습니다.
<img width="1707" alt="image" src="https://github.com/hoops-project/frontend/assets/107461545/d9914e51-bce5-4e6d-afd7-2d6fd842c997">
<img width="1710" alt="image" src="https://github.com/hoops-project/frontend/assets/107461545/cd8b1502-cfaf-464b-80a5-257287ae2d75">
