### PR TITLE
hoops #66 경기 생성 페이지 서버 연동 및 쿼리 작성

### DIFF
--- a/src/components/GameSelectList/GameSelectList.tsx
+++ b/src/components/GameSelectList/GameSelectList.tsx
@@ -18,7 +18,7 @@ export default function GameSelectList({ selected }: GameSelectedProps) {
         name={'경기'}
         options={OPTIONS.GAME_TYPE}
         size={'small'}
-        width={80}
+        width={90}
         value={selected.gameType}
         setValue={selected.setGameType}
       />
@@ -50,7 +50,7 @@ export default function GameSelectList({ selected }: GameSelectedProps) {
         name={'시간'}
         options={OPTIONS.GAME_TIME}
         size={'small'}
-        width={80}
+        width={85}
         value={selected.time}
         setValue={selected.setTime}
       />
@@ -58,7 +58,7 @@ export default function GameSelectList({ selected }: GameSelectedProps) {
         name={'날짜'}
         options={OPTIONS.GAME_DATE}
         size={'small'}
-        width={80}
+        width={120}
         value={selected.date}
         setValue={selected.setDate}
       />

--- a/src/components/common/BasicTextArea/BasicTextArea.style.ts
+++ b/src/components/common/BasicTextArea/BasicTextArea.style.ts
@@ -3,7 +3,7 @@ import { theme } from '../../../styles/theme.ts'
 
 export const S = {
   TextArea: styled.textarea`
-    width: 100%;
+    width: calc(100% - 3rem);
     min-height: 30rem;
     resize: none;
     border: 0.1rem solid ${theme.colors.gray_400};

--- a/src/components/common/BasicTextArea/BasicTextArea.style.ts
+++ b/src/components/common/BasicTextArea/BasicTextArea.style.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+import { theme } from '../../../styles/theme.ts'
+
+export const S = {
+  TextArea: styled.textarea`
+    width: 100%;
+    min-height: 30rem;
+    resize: none;
+    border: 0.1rem solid ${theme.colors.gray_400};
+    background-color: ${theme.colors.white_gray};
+    padding: 1.5rem;
+    outline: none;
+    font-size: 1.6rem;
+    border-radius: 0.8rem;
+  `,
+}

--- a/src/components/common/BasicTextArea/BasicTextArea.style.ts
+++ b/src/components/common/BasicTextArea/BasicTextArea.style.ts
@@ -12,5 +12,9 @@ export const S = {
     outline: none;
     font-size: 1.6rem;
     border-radius: 0.8rem;
+
+    &::placeholder {
+      color: ${theme.colors.gray_400};
+    }
   `,
 }

--- a/src/components/common/BasicTextArea/BasicTextArea.tsx
+++ b/src/components/common/BasicTextArea/BasicTextArea.tsx
@@ -1,0 +1,22 @@
+import { S } from './BasicTextArea.style.ts'
+import React from 'react'
+
+interface BasicTextAreaProps {
+  placeholder?: string
+  content: string
+  setContent: React.Dispatch<React.SetStateAction<string>>
+}
+
+export default function BasicTextArea({
+  placeholder,
+  setContent,
+  content,
+}: BasicTextAreaProps) {
+  return (
+    <S.TextArea
+      placeholder={placeholder}
+      value={content}
+      onChange={(e) => setContent(e.target.value)}
+    ></S.TextArea>
+  )
+}

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -4,7 +4,7 @@ export const REGEX = {
   UPPERCASE: /[A-Z]/,
   LOWERCASE: /[a-z]/,
   INCLUDE_NUMBER: /\d/,
-  SPECIAL_SYMBOL: /[@$!%*?&]/,
+  SPECIAL_SYMBOL: /[@$!%*?&#]/,
 }
 
 Object.freeze(REGEX)

--- a/src/constants/selectOption.ts
+++ b/src/constants/selectOption.ts
@@ -39,8 +39,8 @@ export const OPTIONS = {
   GAME_TIME: generateGameTimeObjects(),
   TOTAL_PLAYERS: generateTotalPlayersObjects(),
   ADD_FRIEND: [
-    { NAME: '허용', VALUE: 'ALLOW' },
-    { NAME: '불가', VALUE: 'DISALLOW' },
+    { NAME: '허용', VALUE: 'TRUE' },
+    { NAME: '불가', VALUE: 'FALSE' },
     { NAME: '선택취소', VALUE: '' },
   ],
   GAME_PLACE: [

--- a/src/constants/validRules.ts
+++ b/src/constants/validRules.ts
@@ -18,8 +18,8 @@ export const VALID_RULES = deepFreeze({
         value.length <= 13 || '비밀번호는 최대 13자리를 넘을 수 없습니다.',
       containsUppercase: (value: string) =>
         REGEX.UPPERCASE.test(value) || '비밀번호에 대문자가 포함되어야 합니다.',
-      containsLowercase: (value: string) =>
-        REGEX.LOWERCASE.test(value) || '비밀번호에 소문자가 포함되어야 합니다.',
+      // containsLowercase: (value: string) =>
+      //   REGEX.LOWERCASE.test(value) || '비밀번호에 소문자가 포함되어야 합니다.',
       containsNumber: (value: string) =>
         REGEX.INCLUDE_NUMBER.test(value) ||
         '비밀번호에 숫자가 포함되어야 합니다.',

--- a/src/helper/generateObjectsArray.ts
+++ b/src/helper/generateObjectsArray.ts
@@ -31,7 +31,7 @@ export const generateNextTwoWeeksDates = () => {
 export const generateTotalPlayersObjects = () => {
   const totalPlayers = []
 
-  for (let i = 1; i <= 12; i++) {
+  for (let i = 6; i <= 15; i++) {
     totalPlayers.push({ NAME: `${i}명`, VALUE: `${i}` })
   }
 

--- a/src/hooks/query/useAddGameQuery.ts
+++ b/src/hooks/query/useAddGameQuery.ts
@@ -1,0 +1,45 @@
+import { axiosAuth } from '../../api/axiosInstance.ts'
+import { END_POINT } from '../../constants/endPoint.ts'
+import { useMutation } from '@tanstack/react-query'
+import { GameData } from '../../types/game.ts'
+import useToast from '../useToast.ts'
+import { AxiosError } from 'axios'
+import { useNavigate } from 'react-router-dom'
+
+export const useAddGameQuery = () => {
+  const { toastError, toastSuccess } = useToast()
+  const navigate = useNavigate()
+
+  const addGame = async (gameData: Partial<GameData>) => {
+    const { data } = await axiosAuth.post(END_POINT.GAME_CREATOR.CREATE_GAME, {
+      title: gameData.title,
+      content: gameData.content,
+      headCount: gameData.totalPlayers,
+      fieldStatus: gameData.gamePlace,
+      gender: gameData.gender,
+      startDateTime: `${gameData.date}T${gameData.time}:00`,
+      inviteYn: gameData.addFriends === 'TRUE',
+      address: gameData.address,
+      matchFormat: gameData.gameType,
+      latitude: gameData.lat,
+      longitude: gameData.lng,
+    })
+
+    return data
+  }
+
+  const { mutate: addGameMutation } = useMutation({
+    mutationFn: addGame,
+    onSuccess: () => {
+      navigate('/my-game')
+      toastSuccess('경기가 생성되었습니다!')
+    },
+    onError: (error: AxiosError) => {
+      if (error?.response?.status === 400) {
+        toastError('오류가 발생했습니다.')
+      }
+    },
+  })
+
+  return { addGameMutation }
+}

--- a/src/hooks/useGameInfo.ts
+++ b/src/hooks/useGameInfo.ts
@@ -1,0 +1,31 @@
+import React, { useState } from 'react'
+import { AddressProps } from '../types/map.ts'
+
+export const useGameInfo = (
+  initialGameTitle = '',
+  initialGameContent = '',
+  initialAddress: Partial<AddressProps> = {}
+) => {
+  const [gameTitle, setGameTitle] = useState<string>(initialGameTitle)
+  const [gameContent, setGameContent] = useState<string>(initialGameContent)
+  const [address, setAddress] = useState<AddressProps>({
+    placeName: initialAddress.placeName || '',
+    address: initialAddress.address || '',
+    lat: initialAddress.lat || '',
+    lng: initialAddress.lng || '',
+  })
+
+  const handleGameTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value
+    setGameTitle(inputValue)
+  }
+
+  return {
+    gameTitle,
+    gameContent,
+    address,
+    handleGameTitleChange,
+    setGameContent,
+    setAddress,
+  }
+}

--- a/src/pages/AddGame/AddGame.style.ts
+++ b/src/pages/AddGame/AddGame.style.ts
@@ -14,7 +14,7 @@ export const S = {
 
     & > label {
       display: block;
-      padding: 1rem 0 1rem 0;
+      padding: 2rem 0 2rem 0;
       color: ${(props) => props.theme.colors.gray_700};
     }
   `,

--- a/src/pages/AddGame/AddGame.tsx
+++ b/src/pages/AddGame/AddGame.tsx
@@ -31,6 +31,16 @@ export default function AddGame() {
     const headCount = useGameSelect.totalPlayers
     const matchFormat = useGameSelect.gameType
 
+    if (gameTitle.length > 50) {
+      toastError('경기 제목은 500자 이하로 작성해 주세요.')
+      return
+    }
+
+    if (gameContent.length > 500) {
+      toastError('경기 규칙은 500자 이하로 작성해 주세요.')
+      return
+    }
+
     if (matchFormat === 'THREEONTHREE') {
       if (Number(headCount) < 6 || Number(headCount) > 9) {
         toastError('3대3에서의 인원은 6~9명 사이 입니다.')
@@ -43,7 +53,7 @@ export default function AddGame() {
       }
     }
 
-    const combineData = {
+    const finalData = {
       ...address,
       ...useGameSelect,
       title: gameTitle,
@@ -52,14 +62,14 @@ export default function AddGame() {
       showOver: 'temp',
     }
 
-    for (const value of Object.values(combineData)) {
+    for (const value of Object.values(finalData)) {
       if (typeof value === 'string' && value.trim() === '') {
         toastError('모든 정보를 입력해 주세요!')
         return
       }
     }
 
-    addGameMutation(combineData)
+    addGameMutation(finalData)
   }
 
   return (
@@ -77,7 +87,7 @@ export default function AddGame() {
               id={'game-title'}
               placeholder={'모임 이름을 설정하세요.'}
             />
-            <label htmlFor={'game-content'}>모임 이름</label>
+            <label htmlFor={'game-content'}>경기 규칙</label>
             <BasicTextArea
               content={gameContent}
               setContent={setGameContent}

--- a/src/pages/AddGame/AddGame.tsx
+++ b/src/pages/AddGame/AddGame.tsx
@@ -6,23 +6,21 @@ import BasicInput from '../../components/common/BasicInput/BasicInput.tsx'
 import { S } from './AddGame.style.ts'
 import BasicButton from '../../components/common/BasicButton/BasicButton.tsx'
 import { theme } from '../../styles/theme.ts'
-import { AddressProps } from '../../types/map.ts'
 import LocationSearchForm from '../../components/LocationSearchForm/LocationSearchForm.tsx'
-import { useState } from 'react'
 import BasicTextArea from '../../components/common/BasicTextArea/BasicTextArea.tsx'
 import useToast from '../../hooks/useToast.ts'
 import { useAddGameQuery } from '../../hooks/query/useAddGameQuery.ts'
+import { useGameInfo } from '../../hooks/useGameInfo.ts'
 
 export default function AddGame() {
-  const [gameTitle, setGameTitle] = useState<string>('')
-  const [gameContent, setGameContent] = useState<string>('')
-
-  const [address, setAddress] = useState<AddressProps>({
-    placeName: '',
-    address: '',
-    lat: '',
-    lng: '',
-  })
+  const {
+    gameTitle,
+    gameContent,
+    address,
+    handleGameTitleChange,
+    setGameContent,
+    setAddress,
+  } = useGameInfo()
   const useGameSelect = useSelectBox()
   const { toastError } = useToast()
   const { addGameMutation } = useAddGameQuery()
@@ -82,7 +80,7 @@ export default function AddGame() {
             <label htmlFor={'game-title'}>모임 이름</label>
             <BasicInput
               value={gameTitle}
-              onChange={(e) => setGameTitle(e.target.value)}
+              onChange={handleGameTitleChange}
               type={'text'}
               id={'game-title'}
               placeholder={'모임 이름을 설정하세요.'}

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -18,3 +18,21 @@ export interface MyGameUserList {
     rate: number
   }[]
 }
+
+export interface GameData {
+  addFriends: string
+  address: string
+  date: string
+  gamePlace: string
+  gameType: string
+  gender: string
+  lat: string
+  lng: string
+  placeName: string
+  region: string
+  showOver: string
+  time: string
+  title: string
+  content: string
+  totalPlayers: string
+}


### PR DESCRIPTION
작업 목적
- 경기 생성 페이지 서버 연동 및 쿼리 작성

작업 내용
- 경기 생성시 누락된 정보가 있으면 프론트단에서 검사하여 요청을 보내지 못하도록 막았습니다.
- 경기 규칙을 적기 위한 BasicTextArea 컴포넌트를 추가하였습니다. 추후 신고 내용을 작성할때도 사용될것 같아 common 폴더에 추가하였습니다.
- 모임 이름과 경기 규칙은 각각 50자 500자를 넘지 못하게 설정하였습니다.
- 3 vs 3 경기는 6~9명 사이의 인원수를 선택 가능하며 5 vs 5는 10 ~ 15명 사이의 인원수를 선택해야만 경기가 생성되도록 제한 하였습니다.
- 셀렉트박스에서 날짜와 시간을 선택할시 선택한 시간날짜가 보이지 않아 가로 길이를 늘렸습니다.
- 이후 경기 수정을 위한 페이지 생성시 경기 제목과 경기규칙, 지도 정보의 state관리 로직 중복을 줄이기 위해 커스텀 훅으로 묶었습니다.
- 경기 생성이 완료되면 나의 경기 목록으로 라우팅 되도록 하였습니다.
- 경기 생성 이후 채팅방 생성 및 연결은 추후로 우선순위를 미루겠습니다.

![image](https://github.com/hoops-project/frontend/assets/107461545/1587b3c9-ab6b-49f8-a5c7-b79a3e7d415b)
![image](https://github.com/hoops-project/frontend/assets/107461545/2e91f779-2dac-4715-9f33-9c38ded3852c)
![image](https://github.com/hoops-project/frontend/assets/107461545/d67a1aac-a96b-443c-be57-c21611e7f950)

