### PR TITLE
hoops #70 프라이빗 라우팅 및 로그아웃/회원탈퇴 기능 구현

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosRequestConfig } from 'axios';
-import { useUserStore } from '../store/store';
 import { END_POINT } from '../constants/endPoint';
 
 export const defaultAxios = axios.create({
@@ -40,28 +39,24 @@ axiosAuth.interceptors.request.use(
     return Promise.reject(error);
   }
 );
-
 const refreshToken = async (req: AxiosRequestConfig) => {
-  const updateUser = useUserStore.getState().updateUser;
   try {
     const res = await axiosAccess.post(`${END_POINT.AUTH.REFRESH_TOKEN}`);
     const newACToken = res.headers["access-token"];
     localStorage.setItem("Access-Token", newACToken);
-    
-   // headers가 undefined인 경우 초기화  
+
+    // headers가 undefined인 경우 초기화
     if (!req.headers) {
       req.headers = {};
     }
     req.headers.Authorization = `Bearer ${newACToken}`;
     return await axiosAuth(req);
   } catch (err) {
-    updateUser({ isLogin: false });
-    alert("로그인을 다시 진행해주세요.");
-    window.location.replace("/sign-in");
+    alert('다시 로그인해주세요!');
+    window.location.replace('/sign-in');
     throw err;
   }
 };
-
 // access-token 만료시 refresh-token 사용해서 재발급
 axiosAuth.interceptors.response.use(
   (response) => response,

--- a/src/components/Notification/Notification.style.ts
+++ b/src/components/Notification/Notification.style.ts
@@ -41,7 +41,7 @@ export const S = {
     overflow-y: scroll;
     margin-top: 2rem;
     background-color: ${(props) => props.theme.colors.white_gray};
-    height: 85%;
+    height: 75%;
     padding: 2rem;
   `,
   NoticeItem: styled.div`
@@ -60,4 +60,16 @@ export const S = {
       height: 2rem;
     }
   `,
+  Logout: styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+
+  & > span {
+    cursor: pointer;
+    padding: 1rem;
+    font-size: 1.5rem;
+    color: ${(props) => props.theme.colors.gray_500};
+  }
+  `
 }

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -2,14 +2,45 @@ import { S } from './Notification.style.ts'
 import noticeBell from '../../assets/fluent-emoji-flat_bell.svg'
 import { CS } from '../../styles/commonStyle.ts'
 import { PiInfoLight } from 'react-icons/pi'
+import { END_POINT } from '../../constants/endPoint.ts'
+import { useUserInfoQuery } from '../../hooks/query/useUserInfoQuery.ts'
+import { axiosAccess } from '../../api/axiosInstance.ts'
+import { useNavigate } from 'react-router-dom'
+import useDeactivateQuery from '../../hooks/query/useDeActivateQuery.ts'
+import useToast from '../../hooks/useToast.ts'
 
 export default function Notification() {
+  const { toastSuccess } = useToast()
+  const navigate = useNavigate()
+  const { userInfo } = useUserInfoQuery()
+  const { deactivateMutate } = useDeactivateQuery()
+
+  const handleSignOut = async () => {
+    const checkLogout = window.confirm('로그아웃을 하시겠습니까?')
+    if (checkLogout) {
+      await axiosAccess.post(`${END_POINT.AUTH.LOGOUT}`).then(() => {
+
+        localStorage.removeItem("Access-Token")
+      });
+      toastSuccess('로그아웃이 성공적으로 완료되었습니다 💪🏻')
+      navigate("/", { replace: true })
+    }
+  };
+
+  const handleDeactivate = () => {
+    const checkWithdraw = window.confirm("정말 회원 탈퇴를 하시겠습니까?")
+    if (checkWithdraw) {
+      deactivateMutate()
+    }
+  };
+
+
   return (
     <S.Wrapper>
       <S.UserInfo>
-        <p>오신웅</p>
+        <p>{userInfo?.name}</p>
         <div>
-          <span>시눙하이</span> <span>1996.03.28</span>
+          <span>{userInfo?.nickname}</span> <span>{userInfo?.birthday}</span>
         </div>
       </S.UserInfo>
       <S.NoticeTitle>
@@ -26,6 +57,9 @@ export default function Notification() {
           </CS.Link>
         ))}
       </S.NoticeBody>
+      <S.Logout>
+        <span onClick={handleSignOut}>로그아웃</span> <span>|</span> <span onClick={handleDeactivate}>회원탈퇴</span>
+      </S.Logout>
     </S.Wrapper>
   )
 }

--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -8,7 +8,7 @@ export const END_POINT = deepFreeze({
     SIGN_UP: 'api/user/signup',
     EMAIL_CONFIRM: 'api/user/signup/confirm',
     USER_EDIT: 'api/auth/user/edit',
-    DEACTIVATE: 'api/user/deactivate',
+    DEACTIVATE: 'api/auth/deactivate',
     FIND_ID: 'api/user/find/id',
     FIND_PASSWORD: 'api/user/find/password',
     USER_INFO: 'api/auth/user/info',

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -4,6 +4,7 @@ export const QUERY_KEYS = {
   GET_GAME_LIST: 'GET_GAME_LIST',
   LOGIN: 'LOGIN',
   GET_USER_INFO: 'GET_USER_INFO',
+  DEACTIVATE: 'DEACTIVATE',
 }
 
 Object.freeze(QUERY_KEYS)

--- a/src/hooks/query/useDeactivateQuery.ts
+++ b/src/hooks/query/useDeactivateQuery.ts
@@ -1,0 +1,31 @@
+import { axiosAccess } from "../../api/axiosInstance";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { END_POINT } from "../../constants/endPoint";
+import { QUERY_KEYS } from "../../constants/queryKeys";
+import useToast from "../useToast";
+
+const fetchAPI = async () => {
+  const res = await axiosAccess.post(`${END_POINT.USER.DEACTIVATE}`)
+  return res.data
+};
+
+const useDeactivateQuery = () => {
+  const { toastSuccess } = useToast()
+  const navigate = useNavigate()
+
+  const { mutate: deactivateMutate } = useMutation({
+    mutationKey: [QUERY_KEYS.DEACTIVATE],
+    mutationFn: () => fetchAPI(),
+    onSuccess: () => {
+      localStorage.removeItem("Access-Token");
+      localStorage.removeItem("userInfo");
+      toastSuccess("회원탈퇴가 완료되었습니다.");
+      navigate("/", { replace: true });
+    },
+  });
+
+  return { deactivateMutate };
+};
+
+export default useDeactivateQuery;

--- a/src/hooks/query/useLoginQuery.ts
+++ b/src/hooks/query/useLoginQuery.ts
@@ -1,11 +1,11 @@
-import { axiosAccess, defaultAxios } from "../../api/axiosInstance";
+import { defaultAxios } from "../../api/axiosInstance";
 import { SignInType, SignInResponseType } from "../../types/auth";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { QUERY_KEYS } from "../../constants/queryKeys";
 import { END_POINT } from "../../constants/endPoint";
 import{ useToast } from "../useToast";
-import { useUserStore } from "../../store/store";
+
 
 const memberLogin = async (data: SignInType): Promise<SignInResponseType> => {
   const { id, password } = data;
@@ -30,8 +30,6 @@ const memberLogin = async (data: SignInType): Promise<SignInResponseType> => {
 export default function useLoginQuery() {
   const navigate = useNavigate();
   const { toastSuccess, toastError } = useToast();
-  const updateUser = useUserStore((state) => state.updateUser);
-
   const {
     data: loginData,
     mutate: loginMutate,
@@ -49,13 +47,6 @@ export default function useLoginQuery() {
       }
 
       localStorage.setItem('Access-Token', accessToken)
-      //현재 사용자 상태 업데이트
-      const { data: userInfoData } = await axiosAccess.get(
-        END_POINT.USER.USER_INFO
-      )
-      //현재 사용자 상태 전역 관리
-      updateUser(userInfoData)
-      console.log(data.userInfo)
 
       navigate('/', { replace: true })
       toastSuccess('로그인에 성공하셨습니다 💪🏻')

--- a/src/layout/DefaultLayout/DefaultLayout.tsx
+++ b/src/layout/DefaultLayout/DefaultLayout.tsx
@@ -15,6 +15,7 @@ export default function DefaultLayout() {
         autoClose={2000}
         hideProgressBar={false}
         newestOnTop={false}
+        limit={1}
         closeOnClick
         rtl={false}
         pauseOnFocusLoss

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -4,8 +4,21 @@ import BasicButton from '../../components/common/BasicButton/BasicButton.tsx'
 import { theme } from '../../styles/theme.ts'
 import kakao from '../../assets/kakao.svg'
 import SignInForm from '../../components/SignInForm/SignInForm.tsx'
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 export default function SignIn() {
+  const navigate = useNavigate()
+  
+  // 로그인 상태일 시 로그인 화면 경로 제어 
+  const isAuthenticated = localStorage.getItem('Access-Token');
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/', { replace: true });
+    }
+  }, []);
+
   return (
     <CS.DefaultContainer>
       <S.Wrapper>

--- a/src/routes/MainRouter.tsx
+++ b/src/routes/MainRouter.tsx
@@ -14,6 +14,7 @@ import GameChat from '../components/GameChat/GameChat.tsx'
 import WaitChatSelect from '../components/WaitChatSelect/WaitChatSelect.tsx'
 import SearchTab from '../components/SearchTab/SearchTab.tsx'
 import MyLastGameList from '../pages/MyLastGame/MyLastGame.tsx'
+import PrivateRoute from '../routes/PrivateRoute.tsx'
 
 export default function MainRouter() {
   return (
@@ -22,37 +23,39 @@ export default function MainRouter() {
         <Route path={'/'} element={<Main />}></Route>
         <Route path={'/sign-in'} element={<SignIn />} />
         <Route path={'/sign-up'} element={<SignUp />} />
-        <Route path={'/add-game'} element={<AddGame />} />
-        <Route path={'/admin/report'} element={<Report />} />
-        <Route path={'/search'} element={<SearchTab />} />
-        <Route path={'/my-last-game'} element={<MyLastGameList />} />
-        <Route
-          path={'/detail/:id'}
-          element={
-            <ChangeBgLayout $bg={theme.colors.default_gray_bg}>
-              <Detail />
-            </ChangeBgLayout>
-          }
-        />
-        <Route
-          path={'/my-page'}
-          element={
-            <ChangeBgLayout $bg={theme.colors.default_gray_bg}>
-              <MyPage />
-            </ChangeBgLayout>
-          }
-        />
-        <Route
-          path={'/my-game'}
-          element={
-            <ChangeBgLayout $bg={theme.colors.default_gray_bg}>
-              <MyGame />
-            </ChangeBgLayout>
-          }
-        >
-          <Route path={'/my-game'} element={<WaitChatSelect />} />
-          <Route path={'/my-game/:id'} element={<GameChat />} />
-        </Route>
+        <Route element={<PrivateRoute />}>
+          <Route path={'/add-game'} element={<AddGame />} />
+          <Route path={'/admin/report'} element={<Report />} />
+          <Route path={'/search'} element={<SearchTab />} />
+          <Route path={'/my-last-game'} element={<MyLastGameList />} />
+          <Route
+            path={'/detail/:id'}
+            element={
+              <ChangeBgLayout $bg={theme.colors.default_gray_bg}>
+                <Detail />
+              </ChangeBgLayout>
+            }
+          />
+          <Route
+            path={'/my-page'}
+            element={
+              <ChangeBgLayout $bg={theme.colors.default_gray_bg}>
+                <MyPage />
+              </ChangeBgLayout>
+            }
+          />
+          <Route
+            path={'/my-game'}
+            element={
+              <ChangeBgLayout $bg={theme.colors.default_gray_bg}>
+                <MyGame />
+              </ChangeBgLayout>
+            }
+          >
+            <Route path={'/my-game'} element={<WaitChatSelect />} />
+            <Route path={'/my-game/:id'} element={<GameChat />} />
+          </Route>
+      </Route>
       </Route>
     </Routes>
   )

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,0 +1,17 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useToast } from '../hooks/useToast'
+
+
+const PrivateRoute = () => {
+  const { toastError } = useToast()
+  const isAuthenticated = localStorage.getItem('Access-Token')
+  
+    if (!isAuthenticated) {
+      toastError('로그인을 진행해주세요!')
+      return <Navigate to= '/sign-in' />
+    }
+    return <Outlet />
+  }
+
+
+export default PrivateRoute;

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,17 +1,24 @@
-import { Navigate, Outlet } from 'react-router-dom'
-import { useToast } from '../hooks/useToast'
+import React, { useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+import { useToast } from '../hooks/useToast';
 
+const PrivateRoute: React.FC = () => {
+  const { toastError } = useToast();
+  const navigate = useNavigate();
+  const isAuthenticated = localStorage.getItem('Access-Token');
 
-const PrivateRoute = () => {
-  const { toastError } = useToast()
-  const isAuthenticated = localStorage.getItem('Access-Token')
-  
+  useEffect(() => {
     if (!isAuthenticated) {
-      toastError('로그인을 진행해주세요!')
-      return <Navigate to= '/sign-in' />
+      toastError('로그인을 진행해주세요!');
+      navigate('/sign-in');
     }
-    return <Outlet />
+  }, [isAuthenticated, toastError, navigate]);
+
+  if (!isAuthenticated) {
+    return null;
   }
 
+  return <Outlet />;
+};
 
 export default PrivateRoute;


### PR DESCRIPTION
- 프라이빗 라우팅을 사용하여 사용자 로그인 인증을 기반으로 접근하는 페이지 경로를 설정하였습니다. 

✅ 인증이 없으면 접근할 수 없는 페이지: 지난 경기 리스트, 채팅 등에 접근할 때 로그인 화면으로 돌아와 알람이 뜨게 구현하였습니다.

- 마이페이지 내에서 로그아웃/회원탈퇴 가능한 UI 생성 후 커스텀 훅을 활용하여 해당 기능이 작동하도록 구현했습니다.

<img width="767" alt="스크린샷 2024-05-22 오후 9 15 19" src="https://github.com/hoops-project/frontend/assets/138990007/906259ab-3c97-42dd-ba2d-d0680e6d480b">

로그아웃 얼랏이 뜨고 성공 시 토스트 알람이 들어오게 설정했습니다. 

- 로그인 상태 유지 시 로그인 페이지 접근을 차단했습니다.

