### PR TITLE
[fix] 받은 코드리뷰를 바탕으로 userInfo를 완전히 지워 다음 로그인 시 이슈 없게 수정 

### DIFF
--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -7,9 +7,12 @@ import { useUserInfoQuery } from '../../hooks/query/useUserInfoQuery.ts'
 import { axiosAccess } from '../../api/axiosInstance.ts'
 import { useNavigate } from 'react-router-dom'
 import useToast from '../../hooks/useToast.ts'
-import useDeactivateQuery from '../../hooks/query/useDeactivateQuery.ts'
+import useDeactivateQuery from '../../hooks/query/useDeActivateQuery.ts'
+import { useQueryClient } from '@tanstack/react-query'
+import { QUERY_KEYS } from '../../constants/queryKeys.ts'
 
 export default function Notification() {
+  const queryClient = useQueryClient();
   const { toastSuccess } = useToast()
   const navigate = useNavigate()
   const { userInfo } = useUserInfoQuery()
@@ -20,8 +23,13 @@ export default function Notification() {
     if (checkLogout) {
       await axiosAccess.post(`${END_POINT.AUTH.LOGOUT}`).then(() => {
         localStorage.removeItem('Access-Token')
+        queryClient.removeQueries({
+          queryKey: [QUERY_KEYS.GET_USER_INFO],
+          exact: true,
+        })
       })
       toastSuccess('로그아웃이 성공적으로 완료되었습니다 💪🏻')
+      
       navigate('/', { replace: true })
     }
   }

--- a/src/hooks/query/useDeactivateQuery.ts
+++ b/src/hooks/query/useDeactivateQuery.ts
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { END_POINT } from "../../constants/endPoint";
 import { QUERY_KEYS } from "../../constants/queryKeys";
 import useToast from "../useToast";
+import { useQueryClient } from "@tanstack/react-query";
 
 const fetchAPI = async () => {
   const res = await axiosAccess.post(`${END_POINT.USER.DEACTIVATE}`)
@@ -13,6 +14,7 @@ const fetchAPI = async () => {
 const useDeactivateQuery = () => {
   const { toastSuccess } = useToast()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const { mutate: deactivateMutate } = useMutation({
     mutationKey: [QUERY_KEYS.DEACTIVATE],
@@ -20,6 +22,10 @@ const useDeactivateQuery = () => {
     onSuccess: () => {
       localStorage.removeItem("Access-Token");
       localStorage.removeItem("userInfo");
+      queryClient.removeQueries({
+        queryKey: [QUERY_KEYS.GET_USER_INFO],
+        exact: true,
+      })
       toastSuccess("회원탈퇴가 완료되었습니다.");
       navigate("/", { replace: true });
     },

--- a/src/routes/MainRouter.tsx
+++ b/src/routes/MainRouter.tsx
@@ -23,19 +23,19 @@ export default function MainRouter() {
         <Route path={'/'} element={<Main />}></Route>
         <Route path={'/sign-in'} element={<SignIn />} />
         <Route path={'/sign-up'} element={<SignUp />} />
+        <Route
+          path={'/detail/:id'}
+          element={
+            <ChangeBgLayout $bg={theme.colors.default_gray_bg}>
+              <Detail />
+            </ChangeBgLayout>
+          }
+        />        
         <Route element={<PrivateRoute />}>
           <Route path={'/add-game'} element={<AddGame />} />
           <Route path={'/admin/report'} element={<Report />} />
           <Route path={'/search'} element={<SearchTab />} />
           <Route path={'/my-last-game'} element={<MyLastGameList />} />
-          <Route
-            path={'/detail/:id'}
-            element={
-              <ChangeBgLayout $bg={theme.colors.default_gray_bg}>
-                <Detail />
-              </ChangeBgLayout>
-            }
-          />
           <Route
             path={'/my-page'}
             element={
@@ -52,11 +52,11 @@ export default function MainRouter() {
               </ChangeBgLayout>
             }
           >
-            <Route path={'/my-game'} element={<WaitChatSelect />} />
-            <Route path={'/my-game/:id'} element={<GameChat />} />
-          </Route>
+          <Route path={'/my-game'} element={<WaitChatSelect />} />
+          <Route path={'/my-game/:id'} element={<GameChat />} />
+        </Route>
       </Route>
-      </Route>
-    </Routes>
+    </Route>
+  </Routes>
   )
 }


### PR DESCRIPTION
- useQueryClient를 사용해서 로그아웃 시 해당 userInfo를 완전히 지워주는 로직 추가 
- PrivateRoute를 필요로 하지 않는 경기 상세 페이지 라우팅 제외 