### PR TITLE
hotfix: 알림 구독시 주소를 잘못 입력하여 404 에러가 발생한 문제 해결

### DIFF
--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -71,7 +71,7 @@ export const END_POINT = deepFreeze({
     REJECT: 'api/invite/receive/reject',
   },
   NOTIFICATION: {
-    SUBSCRIBE: '/subscribe',
+    SUBSCRIBE: 'api/subscribe',
     GET_NOTIFICATION: 'api/notifications',
   },
 })

--- a/src/layout/DefaultLayout/DefaultLayout.tsx
+++ b/src/layout/DefaultLayout/DefaultLayout.tsx
@@ -24,17 +24,14 @@ export default function DefaultLayout() {
       try {
         const lastEventID = localStorage.getItem('sseLastEventID') || null
 
-        eventSource = new EventSource(
-          `api/${END_POINT.NOTIFICATION.SUBSCRIBE}`,
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              LastEventID: JSON.stringify({ lastEventID }),
-            },
-            withCredentials: true,
-            heartbeatTimeout: 120000000,
-          }
-        )
+        eventSource = new EventSource(`${END_POINT.NOTIFICATION.SUBSCRIBE}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            LastEventID: JSON.stringify({ lastEventID }),
+          },
+          withCredentials: true,
+          heartbeatTimeout: 120000000,
+        })
 
         eventSource.onmessage = async (event) => {
           const res = await event.data


### PR DESCRIPTION
 알림 구독시 주소를 잘못 입력하여 404 에러가 발생한 문제 해결